### PR TITLE
Fix extra semicolon warning

### DIFF
--- a/scripts/msg.h.template
+++ b/scripts/msg.h.template
@@ -224,7 +224,7 @@ namespace serialization
     {}
 @[end if]@
 
-    ROS_DECLARE_ALLINONE_SERIALIZER;
+    ROS_DECLARE_ALLINONE_SERIALIZER
   }; // struct @(cpp_class)
 
 } // namespace serialization


### PR DESCRIPTION
When compiling packages that include generated message headers with `-Wpedantic`, the warning

```
 warning: extra ‘;’ [-Wpedantic]
```

is generated by GCC 4.9.3, 5.3.0, and 6.1.1. This is because `ROS_DECLARE_ALLINONE_SERIALIZER` is defined as:

``` cpp
#define ROS_DECLARE_ALLINONE_SERIALIZER \
  template<typename Stream, typename T> \
  inline static void write(Stream& stream, const T& t) \
  { \
    allInOne<Stream, const T&>(stream, t); \
  } \
  \
  template<typename Stream, typename T> \
  inline static void read(Stream& stream, T& t) \
  { \
    allInOne<Stream, T&>(stream, t); \
  } \
  \
  template<typename T> \
  inline static uint32_t serializedLength(const T& t) \
  { \
    LStream stream; \
    allInOne<LStream, const T&>(stream, t); \
    return stream.getLength(); \
  }
```

So the `;` after inserting `ROS_DECLARE_ALLINONE_SERIALIZER` is clearly superfluous.

Don't know if there are other places where this needs to be fixed, too. Maybe [here](https://github.com/ros/ros_comm/blob/9b0600e52530761bf389828afe78e1d98c6a46c0/clients/roscpp/rosbuild/scripts/msg_gen.py#L673)?
