### PR TITLE
Drop rosdoc configuration

### DIFF
--- a/rosdoc.yaml
+++ b/rosdoc.yaml
@@ -1,2 +1,0 @@
- - builder: sphinx
-   sphinx_root_dir: doc


### PR DESCRIPTION
It doesn't do anything: http://docs.ros.org/jade/api/gencpp/html/