### PR TITLE
Add plugin support for generated C++ message headers

### DIFF
--- a/cmake/gencpp-extras.cmake.em
+++ b/cmake/gencpp-extras.cmake.em
@@ -21,7 +21,7 @@ macro(_generate_msg_cpp ARG_PKG ARG_MSG ARG_IFLAGS ARG_MSG_DEPS ARG_GEN_OUTPUT_D
   set(GEN_OUTPUT_FILE ${ARG_GEN_OUTPUT_DIR}/${MSG_GENERATED_NAME})
 
   # check if a user-provided header file exists
-  if(EXISTS ${PROJECT_SOURCE_DIR}/include/${ARG_PKG}/${MSG_SHORT_NAME}.h)
+  if(EXISTS "${PROJECT_SOURCE_DIR}/include/${ARG_PKG}/${MSG_SHORT_NAME}.h")
     # Do nothing. The header will be installed by the user.
   else()
     assert(CATKIN_ENV)

--- a/cmake/gencpp-extras.cmake.em
+++ b/cmake/gencpp-extras.cmake.em
@@ -20,17 +20,23 @@ macro(_generate_msg_cpp ARG_PKG ARG_MSG ARG_IFLAGS ARG_MSG_DEPS ARG_GEN_OUTPUT_D
   set(MSG_GENERATED_NAME ${MSG_SHORT_NAME}.h)
   set(GEN_OUTPUT_FILE ${ARG_GEN_OUTPUT_DIR}/${MSG_GENERATED_NAME})
 
-  assert(CATKIN_ENV)
-  add_custom_command(OUTPUT ${GEN_OUTPUT_FILE}
-    DEPENDS ${GENCPP_BIN} ${ARG_MSG} ${ARG_MSG_DEPS} "${GENCPP_TEMPLATE_DIR}/msg.h.template" ${ARGN}
-    COMMAND ${CATKIN_ENV} ${PYTHON_EXECUTABLE} ${GENCPP_BIN} ${ARG_MSG}
-    ${ARG_IFLAGS}
-    -p ${ARG_PKG}
-    -o ${ARG_GEN_OUTPUT_DIR}
-    -e ${GENCPP_TEMPLATE_DIR}
-    COMMENT "Generating C++ code from ${ARG_PKG}/${MSG_NAME}"
-    )
-  list(APPEND ALL_GEN_OUTPUT_FILES_cpp ${GEN_OUTPUT_FILE})
+  # check if a user-provided header file exists
+  if(EXISTS ${PROJECT_SOURCE_DIR}/include/${ARG_PKG}/${MSG_SHORT_NAME}.h)
+    # Do nothing. The header will be installed by the user.
+  else()
+    assert(CATKIN_ENV)
+    add_custom_command(OUTPUT ${GEN_OUTPUT_FILE}
+      DEPENDS ${GENCPP_BIN} ${ARG_MSG} ${ARG_MSG_DEPS} "${GENCPP_TEMPLATE_DIR}/msg.h.template" ${ARGN}
+      COMMAND ${CATKIN_ENV} ${PYTHON_EXECUTABLE} ${GENCPP_BIN} ${ARG_MSG}
+      ${ARG_IFLAGS}
+      -p ${ARG_PKG}
+      -o ${ARG_GEN_OUTPUT_DIR}
+      -e ${GENCPP_TEMPLATE_DIR}
+      COMMENT "Generating C++ code from ${ARG_PKG}/${MSG_NAME}"
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+      )
+    list(APPEND ALL_GEN_OUTPUT_FILES_cpp ${GEN_OUTPUT_FILE})
+  endif()
 
   gencpp_append_include_dirs()
 endmacro()

--- a/cmake/gencpp-extras.cmake.em
+++ b/cmake/gencpp-extras.cmake.em
@@ -22,11 +22,22 @@ macro(_generate_msg_cpp ARG_PKG ARG_MSG ARG_IFLAGS ARG_MSG_DEPS ARG_GEN_OUTPUT_D
 
   # check if a user-provided header file exists
   if(EXISTS "${PROJECT_SOURCE_DIR}/include/${ARG_PKG}/${MSG_SHORT_NAME}.h")
+    message(STATUS "${ARG_PKG}: Found user-provided header '${PROJECT_SOURCE_DIR}/include/${ARG_PKG}/${MSG_SHORT_NAME}.h' for message '${ARG_PKG}/${MSG_SHORT_NAME}'. Skipping generation...")
     # Do nothing. The header will be installed by the user.
   else()
+    # check if a user-provided plugin header file exists
+    if(EXISTS "${PROJECT_SOURCE_DIR}/include/${ARG_PKG}/plugin/${MSG_SHORT_NAME}.h")
+      message(STATUS "${ARG_PKG}: Found user-provided plugin header '${PROJECT_SOURCE_DIR}/include/${ARG_PKG}/plugin/${MSG_SHORT_NAME}.h' for message '${ARG_PKG}/${MSG_SHORT_NAME}'.")
+      # Add a file dependency to enforce regeneration if the plugin header was added after initial cmake invocation.
+      # Even with --force-cmake the generator would otherwise not run if the .msg file did not change.
+      set(MSG_PLUGIN "${PROJECT_SOURCE_DIR}/include/${ARG_PKG}/plugin/${MSG_SHORT_NAME}.h")
+    else()
+      set(MSG_PLUGIN)
+    endif()
+
     assert(CATKIN_ENV)
     add_custom_command(OUTPUT ${GEN_OUTPUT_FILE}
-      DEPENDS ${GENCPP_BIN} ${ARG_MSG} ${ARG_MSG_DEPS} "${GENCPP_TEMPLATE_DIR}/msg.h.template" ${ARGN}
+      DEPENDS ${GENCPP_BIN} ${ARG_MSG} ${ARG_MSG_DEPS} ${MSG_PLUGIN} "${GENCPP_TEMPLATE_DIR}/msg.h.template" ${ARGN}
       COMMAND ${CATKIN_ENV} ${PYTHON_EXECUTABLE} ${GENCPP_BIN} ${ARG_MSG}
       ${ARG_IFLAGS}
       -p ${ARG_PKG}

--- a/scripts/msg.h.template
+++ b/scripts/msg.h.template
@@ -18,12 +18,14 @@
 @{
 import genmsg.msgs
 import gencpp
+import os
 
 cpp_namespace = '::%s::'%(spec.package) # TODO handle nested namespace
 cpp_class = '%s_'%spec.short_name
 cpp_full_name = '%s%s'%(cpp_namespace,cpp_class)
 cpp_full_name_with_alloc = '%s<ContainerAllocator>'%(cpp_full_name)
 cpp_msg_definition = gencpp.escape_message_definition(msg_definition)
+has_plugin = os.path.exists('include/%s/plugin/%s.h' % (spec.package, spec.short_name))
 }@
 
 #ifndef @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_H
@@ -56,16 +58,11 @@ for field in spec.parsed_fields():
       print('#include <%s/%s.h>'%(package, name))
 }@
 @##############################
-@# Plugins
+@# Plugin
 @##############################
-@{
-import os;
-if os.path.exists('include/%s/plugin/%s.h'%(spec.package, spec.short_name)):
-  have_plugin = True
-  print('#include <%s/plugin/%s.h>'%(spec.package, spec.short_name));
-else:
-  have_plugin = False
-}@
+@[if has_plugin]@
+#include <@(spec.package)/plugin/@(spec.short_name).h>
+@[end if]@
 
 namespace @(spec.package)
 {
@@ -75,8 +72,8 @@ struct @(spec.short_name)_
   typedef @(spec.short_name)_<ContainerAllocator> Type;
 
 @# constructors (with and without allocator)
-@[if have_plugin]@
-#ifndef @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_CUSTOM_CONSTRUCTOR
+@[if has_plugin]@
+#ifndef @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_PLUGIN_CONSTRUCTOR
 @[end if]@
 @[for (alloc_type,alloc_name) in [['',''],['const ContainerAllocator& ','_alloc']]]@
   @(spec.short_name)_(@(alloc_type+alloc_name))
@@ -90,9 +87,9 @@ struct @(spec.short_name)_
   @('\n  '.join(gencpp.generate_fixed_length_assigns(spec, alloc_name != '', '%s::'%(spec.package))))@
   }
 @[end for]
-@[if have_plugin]@
+@[if has_plugin]@
 #else
-  @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_CUSTOM_CONSTRUCTOR
+  @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_PLUGIN_CONSTRUCTOR
 #endif
 @[end if]@
 
@@ -117,10 +114,10 @@ struct @(spec.short_name)_
   typedef boost::shared_ptr< @(cpp_full_name)<ContainerAllocator> > Ptr;
   typedef boost::shared_ptr< @(cpp_full_name)<ContainerAllocator> const> ConstPtr;
 
-@# Plugins
-@[if have_plugin]@
-#ifdef @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_PLUGIN
-  @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_PLUGIN
+@# Class body extensions provided by plugin
+@[if has_plugin]@
+#ifdef @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_PLUGIN_CLASS_BODY
+  @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_PLUGIN_CLASS_BODY
 #endif
 @[end if]@
 }; // struct @(cpp_class)
@@ -235,8 +232,8 @@ namespace ros
 namespace serialization
 {
 
-@[if have_plugin]@
-#ifndef @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_CUSTOM_SERIALIZER
+@[if has_plugin]@
+#ifndef @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_PLUGIN_SERIALIZER
 @[end if]@
   template<class ContainerAllocator> struct Serializer< @(cpp_full_name_with_alloc) >
   {
@@ -254,9 +251,9 @@ namespace serialization
 
     ROS_DECLARE_ALLINONE_SERIALIZER
   }; // struct @(cpp_class)
-@[if have_plugin]@
+@[if has_plugin]@
 #else
-  @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_CUSTOM_SERIALIZER
+  @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_PLUGIN_SERIALIZER
 #endif
 @[end if]@
 
@@ -270,8 +267,8 @@ namespace message_operations
 {
 
 @# Printer operation
-@[if have_plugin]@
-#ifndef @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_CUSTOM_PRINTER
+@[if has_plugin]@
+#ifndef @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_PLUGIN_PRINTER
 @[end if]@
 template<class ContainerAllocator>
 struct Printer< @(cpp_full_name_with_alloc) >
@@ -308,9 +305,9 @@ for field in spec.parsed_fields():
   {}
 @[end if]@
 };
-@[if have_plugin]@
+@[if has_plugin]@
 #else
-  @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_CUSTOM_PRINTER
+  @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_PLUGIN_PRINTER
 #endif
 @[end if]@
 

--- a/scripts/msg.h.template
+++ b/scripts/msg.h.template
@@ -55,6 +55,17 @@ for field in spec.parsed_fields():
       package = package or spec.package # convert '' to package
       print('#include <%s/%s.h>'%(package, name))
 }@
+@##############################
+@# Plugins
+@##############################
+@{
+import os;
+if os.path.exists('include/%s/plugin/%s.h'%(spec.package, spec.short_name)):
+  have_plugin = True
+  print('#include <%s/plugin/%s.h>'%(spec.package, spec.short_name));
+else:
+  have_plugin = False
+}@
 
 namespace @(spec.package)
 {
@@ -64,6 +75,9 @@ struct @(spec.short_name)_
   typedef @(spec.short_name)_<ContainerAllocator> Type;
 
 @# constructors (with and without allocator)
+@[if have_plugin]@
+#ifndef @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_CUSTOM_CONSTRUCTOR
+@[end if]@
 @[for (alloc_type,alloc_name) in [['',''],['const ContainerAllocator& ','_alloc']]]@
   @(spec.short_name)_(@(alloc_type+alloc_name))
 @# Write initializer list
@@ -76,6 +90,11 @@ struct @(spec.short_name)_
   @('\n  '.join(gencpp.generate_fixed_length_assigns(spec, alloc_name != '', '%s::'%(spec.package))))@
   }
 @[end for]
+@[if have_plugin]@
+#else
+  @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_CUSTOM_CONSTRUCTOR
+#endif
+@[end if]@
 
 @[for field in spec.parsed_fields()]
  @{cpp_type = gencpp.msg_type_to_cpp(field.type)}@
@@ -98,6 +117,12 @@ struct @(spec.short_name)_
   typedef boost::shared_ptr< @(cpp_full_name)<ContainerAllocator> > Ptr;
   typedef boost::shared_ptr< @(cpp_full_name)<ContainerAllocator> const> ConstPtr;
 
+@# Plugins
+@[if have_plugin]@
+#ifdef @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_PLUGIN
+  @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_PLUGIN
+#endif
+@[end if]@
 }; // struct @(cpp_class)
 
 @# Typedef of template instance using std::allocator
@@ -210,6 +235,9 @@ namespace ros
 namespace serialization
 {
 
+@[if have_plugin]@
+#ifndef @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_CUSTOM_SERIALIZER
+@[end if]@
   template<class ContainerAllocator> struct Serializer< @(cpp_full_name_with_alloc) >
   {
 @[if spec.parsed_fields()]@
@@ -226,6 +254,11 @@ namespace serialization
 
     ROS_DECLARE_ALLINONE_SERIALIZER
   }; // struct @(cpp_class)
+@[if have_plugin]@
+#else
+  @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_CUSTOM_SERIALIZER
+#endif
+@[end if]@
 
 } // namespace serialization
 } // namespace ros
@@ -237,6 +270,9 @@ namespace message_operations
 {
 
 @# Printer operation
+@[if have_plugin]@
+#ifndef @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_CUSTOM_PRINTER
+@[end if]@
 template<class ContainerAllocator>
 struct Printer< @(cpp_full_name_with_alloc) >
 {
@@ -272,6 +308,11 @@ for field in spec.parsed_fields():
   {}
 @[end if]@
 };
+@[if have_plugin]@
+#else
+  @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_CUSTOM_PRINTER
+#endif
+@[end if]@
 
 } // namespace message_operations
 } // namespace ros

--- a/scripts/msg.h.template
+++ b/scripts/msg.h.template
@@ -73,7 +73,9 @@ struct @(spec.short_name)_
 
 @# constructors (with and without allocator)
 @[if has_plugin]@
-#ifndef @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_PLUGIN_CONSTRUCTOR
+#ifdef @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_PLUGIN_CONSTRUCTOR
+  @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_PLUGIN_CONSTRUCTOR
+#else
 @[end if]@
 @[for (alloc_type,alloc_name) in [['',''],['const ContainerAllocator& ','_alloc']]]@
   @(spec.short_name)_(@(alloc_type+alloc_name))
@@ -88,8 +90,6 @@ struct @(spec.short_name)_
   }
 @[end for]
 @[if has_plugin]@
-#else
-  @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_PLUGIN_CONSTRUCTOR
 #endif
 @[end if]@
 
@@ -233,7 +233,9 @@ namespace serialization
 {
 
 @[if has_plugin]@
-#ifndef @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_PLUGIN_SERIALIZER
+#ifdef @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_PLUGIN_SERIALIZER
+  @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_PLUGIN_SERIALIZER
+#else
 @[end if]@
   template<class ContainerAllocator> struct Serializer< @(cpp_full_name_with_alloc) >
   {
@@ -252,8 +254,6 @@ namespace serialization
     ROS_DECLARE_ALLINONE_SERIALIZER
   }; // struct @(cpp_class)
 @[if has_plugin]@
-#else
-  @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_PLUGIN_SERIALIZER
 #endif
 @[end if]@
 
@@ -268,7 +268,9 @@ namespace message_operations
 
 @# Printer operation
 @[if has_plugin]@
-#ifndef @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_PLUGIN_PRINTER
+#ifdef @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_PLUGIN_PRINTER
+  @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_PLUGIN_PRINTER
+#else
 @[end if]@
 template<class ContainerAllocator>
 struct Printer< @(cpp_full_name_with_alloc) >
@@ -306,8 +308,6 @@ for field in spec.parsed_fields():
 @[end if]@
 };
 @[if has_plugin]@
-#else
-  @(spec.package.upper())_MESSAGE_@(spec.short_name.upper())_PLUGIN_PRINTER
 #endif
 @[end if]@
 


### PR DESCRIPTION
This pull requests adds plugin support to gencpp. It is motivated by [the plugin feature in Eigen](https://eigen.tuxfamily.org/dox/TopicCustomizing_Plugins.html) to extend the `MatrixBase` class, but uses a slightly different approach. Please consider it as a proof-of-concept, a request for comments and a starting point for discussions.

It is basically a combination of two patches:

1. The possibility to provide user-defined message headers for all or a subset of messages and skip generation completely. Check https://github.com/orocos/kdl_msgs for an example use case, where we completely replace the generated struct with a C++11 template alias for a native KDL type.

2. The possibility to provide a user-defined plugin header. Given that the message type is `foo_msgs/Bar`, a header placed at `include/foo_msgs/plugin/Bar.h` inside the package's source folder can define macros to
   - add custom constructors, member functions or even data members to generated structs (`FOO_MSGS_MESSAGE_PLUGIN_CLASS_BODY`)
   - override the default set of constructors (`FOO_MSGS_MESSAGE_BAR_PLUGIN_CONSTRUCTOR`)
   - override the default serializer (`FOO_MSGS_MESSAGE_BAR_PLUGIN_SERIALIZER`)
   - override the default printer (`FOO_MSGS_MESSAGE_BAR_PLUGIN_PRINTER`)
   - or simply include other useful headers

In any case, if none of the two additional files exists, the generated message header should be exactly the same as without the patch.

Of course as a developer you have to know what you are doing to not break the expected message API or compatibility with other languages. There clearly are some limitations and caveats. The approach is kind of complementary to what is called [C++ type adaptation](http://wiki.ros.org/roscpp/Overview/MessagesSerializationAndAdaptingTypes#Adapting_C.2B-.2B-_Types) in the roscpp tutorials, where another, existing type is adapted to behave like a ROS message for publishing and subscribing, without identifying them. But in some cases extending or customizing an existing message type is more convenient than to adapt another type, especially because those extensions will immediately apply to nested instances, too.

Just to make my point - not necessarily as a serious suggestion - here are some examples that could be applied to messages similar to the ones in [geometry_msgs](http://wiki.ros.org/geometry_msgs):

- add a `Pose` constructor that initializes it with a `position` and `orientation` (C++11 has [list initialization](http://en.cppreference.com/w/cpp/language/list_initialization) as an alternative)
- override the default constructor of a `Quaternion` with one that initializes the scalar component to 1 if desired (unit quaternion), or only for the `Transform` message
- provide some basic math operators for vector- and matrix-like message types
- provide `operator[]` for vectors or matrices
- provide simple helper methods like `setZero()`, `isZero()`, `isValid()`, ...
- modify the textual representation of messages for the console, e.g. adding the norm or RPY output for orientation quaternions

Or, in case of [sensor_msgs](http://wiki.ros.org/sensor_msgs), additional headers like [image_encodings.h](https://github.com/ros/common_msgs/blob/jade-devel/sensor_msgs/include/sensor_msgs/image_encodings.h) could be included by default from the plugin header file.

What I consider as less appropriate is to add conversion functions to and from other types that would add extra dependencies. A separate header file with free functions, like they already exist in various packages today, is the better choice for that purpose.

I assume a similar mechanism could be applied to other generators like [genpy](http://wiki.ros.org/genpy), too, for the sake of consistency.