### PR TITLE
enable Windows build

### DIFF
--- a/scripts/msg.h.template
+++ b/scripts/msg.h.template
@@ -226,11 +226,11 @@ struct @(trait_class)< @(cpp_full_name_with_alloc) >
 {
   static const char* value()
   {
-    @[if trait_class == 'Definition']
-      return @(trait_value);
-    @[else]
-      return "@(trait_value)";
-    @[end if]
+@[if trait_class == 'Definition']@
+    return @(trait_value);
+@[else]@
+    return "@(trait_value)";
+@[end if]@
   }
 
   static const char* value(const @(cpp_full_name_with_alloc)&) { return value(); }

--- a/scripts/msg.h.template
+++ b/scripts/msg.h.template
@@ -226,7 +226,7 @@ struct @(trait_class)< @(cpp_full_name_with_alloc) >
 {
   static const char* value()
   {
-    return "@(trait_value)";
+    return @(trait_value);
   }
 
   static const char* value(const @(cpp_full_name_with_alloc)&) { return value(); }

--- a/scripts/msg.h.template
+++ b/scripts/msg.h.template
@@ -226,7 +226,11 @@ struct @(trait_class)< @(cpp_full_name_with_alloc) >
 {
   static const char* value()
   {
-    return @(trait_value);
+    @[if trait_class == 'Definition']
+      return @(trait_value);
+    @[else]
+      return "@(trait_value)";
+    @[end if]
   }
 
   static const char* value(const @(cpp_full_name_with_alloc)&) { return value(); }

--- a/src/gencpp/__init__.py
+++ b/src/gencpp/__init__.py
@@ -99,7 +99,7 @@ def escape_message_definition(definition):
     s = StringIO()
     for line in lines:
         line = _escape_string(line)
-        s.write('%s\\n\\\n'%(line))
+        s.write('"%s\\n"\n'%(line))
         
     val = s.getvalue()
     s.close()

--- a/src/gencpp/__init__.py
+++ b/src/gencpp/__init__.py
@@ -99,6 +99,8 @@ def escape_message_definition(definition):
     s = StringIO()
     for line in lines:
         line = _escape_string(line)
+        # individual string literals cannot be too long; need to utilize string concatenation for long strings
+        # https://docs.microsoft.com/en-us/cpp/c-language/maximum-string-length?view=vs-2017
         s.write('"%s\\n"\n'%(line))
         
     val = s.getvalue()


### PR DESCRIPTION
this change aims to work with the [maximum string length limit in MSVC](https://docs.microsoft.com/en-us/cpp/c-language/maximum-string-length?view=vs-2017).

prior to this change `return "@(trait_value)";` would return the entire message definition wrapped around 2 double quotes as a single string literal; each line inside the string would be separated by `\`. After this change, each line would be wrapped around its own pair of double quotes.

mentioned in the linked documentation,
```
While an individual quoted string cannot be longer than 2048 bytes, a string literal of roughly 65535 bytes can be constructed by concatenating strings.
```
The final result would still be the same thanks to the string concatenation mechanics.