### PR TITLE
[windows] reducing the odds to have name collisions

### DIFF
--- a/scripts/msg.h.template
+++ b/scripts/msg.h.template
@@ -114,6 +114,13 @@ for constant in spec.constants:
 
 @# Integer constants
 @[if len(constants_integer) > 0]@
+// reducing the odds to have name collisions with Windows.h 
+@[for constant in constants_integer]@
+#if defined(_WIN32) && defined(@(constant.name))
+    #undef @(constant.name)
+#endif
+
+@[end for]@
   enum {
 @[for constant in constants_integer]@
 @[if (constant.type in ['byte', 'int8', 'int16', 'int32', 'int64', 'char'])]@

--- a/scripts/msg.h.template
+++ b/scripts/msg.h.template
@@ -116,12 +116,11 @@ for constant in spec.constants:
 // reducing the odds to have name collisions with Windows.h 
 @[for constant in spec.constants]@
 #if defined(_WIN32) && defined(@(constant.name))
-    #undef @(constant.name)
+  #undef @(constant.name)
 #endif
-
 @[end for]@
-@[end if]@
 
+@[end if]@
 @# Integer constants
 @[if len(constants_integer) > 0]@
   enum {

--- a/scripts/msg.h.template
+++ b/scripts/msg.h.template
@@ -112,15 +112,18 @@ for constant in spec.constants:
     constants_non_integer.append(constant)
 }@
 
-@# Integer constants
-@[if len(constants_integer) > 0]@
+@[if len(spec.constants) > 0]@
 // reducing the odds to have name collisions with Windows.h 
-@[for constant in constants_integer]@
+@[for constant in spec.constants]@
 #if defined(_WIN32) && defined(@(constant.name))
     #undef @(constant.name)
 #endif
 
 @[end for]@
+@[end if]@
+
+@# Integer constants
+@[if len(constants_integer) > 0]@
   enum {
 @[for constant in constants_integer]@
 @[if (constant.type in ['byte', 'int8', 'int16', 'int32', 'int64', 'char'])]@


### PR DESCRIPTION
Even with some effort to reduce the expose of `Windows.h` from several ROS repositories. There are still changes that some external dependencies including `Windows.h`.

This pull request is to propose a mitigation to conditionally `#undef` the type of names with higher odds to have name collision on Windows side. And the goal is to reduce the odds from name collisions without extensive touch-ups on downstream projects.

Here are some examples where the name collisions happen:
* https://github.com/ros/geometry/pull/18
* https://github.com/ros/geometry2/pull/365
(it is not a full list. I will be collecting as I find it..)