### PR TITLE
Fix usage of std::allocator::rebind for C++20

### DIFF
--- a/scripts/msg.h.template
+++ b/scripts/msg.h.template
@@ -41,6 +41,7 @@ has_plugin_after = os.path.exists('include/%s/plugin/%s.after.h' % (spec.package
 
 #include <string>
 #include <vector>
+#include <memory>
 
 #include <ros/types.h>
 #include <ros/serialization.h>

--- a/src/gencpp/__init__.py
+++ b/src/gencpp/__init__.py
@@ -51,7 +51,7 @@ MSG_TYPE_TO_CPP = {
     'int64': 'int64_t',
     'float32': 'float',
     'float64': 'double',
-    'string': 'std::basic_string<char, std::char_traits<char>, typename ContainerAllocator::template rebind<char>::other > ',
+    'string': 'std::basic_string<char, std::char_traits<char>, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<char>>',
     'time': 'ros::Time',
     'duration': 'ros::Duration',
 }
@@ -86,7 +86,7 @@ def msg_type_to_cpp(type_):
 
     if (is_array):
         if (array_len is None):
-            return 'std::vector<%s, typename ContainerAllocator::template rebind<%s>::other > ' % (cpp_type, cpp_type)
+            return 'std::vector<%s, typename std::allocator_traits<ContainerAllocator>::template rebind_alloc<%s>>' % (cpp_type, cpp_type)
         else:
             return 'boost::array<%s, %s> ' % (cpp_type, array_len)
     else:


### PR DESCRIPTION
Messages generated with gencpp still use `std::allocator::rebind` that was deprecated in C++17 and removed in C++20. The replacement is `std::allocator_traits::rebind_alloc` that was introduced in C++11. It is semantically equivalent, so there should be no API or ABI incompabilities introduced through this change.

This fix should make it possible to use ROS in C++20 mode.
