### PR TITLE
Provide templated accessors for attribute value and name.

### DIFF
--- a/scripts/msg.h.template
+++ b/scripts/msg.h.template
@@ -298,6 +298,42 @@ namespace serialization
 @[end if]@
 
     ROS_DECLARE_ALLINONE_SERIALIZER
+
+#if __cplusplus >= 201703L
+    static constexpr std::size_t element_size = @(len(spec.parsed_fields()));
+    template <std::size_t I, typename T>
+    static auto& getField(T& m)
+    {
+@[for i, field in enumerate(spec.parsed_fields())]@
+      if constexpr (I == @(i))
+      {
+        return m.@(field.name);
+      }
+@[end for]@
+
+      if constexpr (I >= element_size)
+      {
+        static_assert(I < element_size, "Field does not exist in the message.");
+      }
+    }
+
+    template <std::size_t I>
+    static constexpr const auto& getFieldName()
+    {
+@[for i, field in enumerate(spec.parsed_fields())]@
+      if constexpr (I == @(i))
+      {
+        return "@(field.name)";
+      }
+@[end for]@
+      if constexpr (I >= element_size)
+      {
+        static_assert(I < element_size, "Field does not exist in the message.");
+        return "";  // We will never reach this statement.
+      }
+    }
+#endif
+
   }; // struct @(cpp_class)
 @[if has_plugin]@
 #endif


### PR DESCRIPTION
Hi,

This adds two templated functions to the serialization struct, these templated functions take an index as a template parameter and based on that provide either the name of that field or the value of that field. This makes it possible to do a compile time template recursion over the message.

This opens up a lot of possibilities; for example it makes it possible to write a recursing template to convert a ros message to an [nlohmann::json](https://github.com/nlohmann/json) object, or allows us to iterate over the message and populate each field with an appropriate random value (floats between 0.0 and 1.0, strings with some dummy content, etc...). Technically it is not strictly limited to serialization, but I thought this was the best place to put these functions, instead of adding static methods to the main struct.

This does make use of c++17 features, since the current ros1 release targets c++14 only I wrapped the additions in a preprocessor if statement. This should make sure it doesn't interfere when compiling using c++14, but is there for use when a target is built with c++17.