### PR TITLE
Fix msg printer for arrays

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package gencpp
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Fix usage of deprecated std::allocator::rebind (`#51 <https://github.com/ros/gencpp/issues/51>`_)
+* Remove unnecessary map include (`#48 <https://github.com/ros/gencpp/issues/48>`_)
+* Contributors: Markus Vieth, poggenhans
+
 0.6.5 (2020-03-03)
 ------------------
 * add operator== & operator!= to message generation (`#41 <https://github.com/ros/gencpp/issues/41>`_)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package gencpp
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.7.0 (2022-09-26)
+------------------
 * Fix usage of deprecated std::allocator::rebind (`#51 <https://github.com/ros/gencpp/issues/51>`_)
 * Remove unnecessary map include (`#48 <https://github.com/ros/gencpp/issues/48>`_)
 * Contributors: Markus Vieth, poggenhans

--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
   schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>gencpp</name>
-  <version>0.6.5</version>
+  <version>0.7.0</version>
   <description>C++ ROS message and service generators.</description>
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>BSD</license>

--- a/scripts/msg.h.template
+++ b/scripts/msg.h.template
@@ -327,26 +327,28 @@ struct Printer< @(cpp_full_name_with_alloc) >
   {
 @# todo, change this stuff below into proper EmPy syntax
 @{
-for field in spec.parsed_fields():
+for i, field in enumerate(spec.parsed_fields()):
   cpp_type = gencpp.msg_type_to_cpp(field.base_type)
+  inline = 'true' if field.is_builtin else 'false'
+  # Print new line for every field except first top-level one
+  print('    if (%s || !indent.empty())'%('true' if i > 0 else 'false'))
+  print('      s << std::endl;')
+  print('    s << indent << "%s: ";'%(field.name))
   if (field.is_array):
-    print('    s << indent << "%s[]" << std::endl;'%(field.name))
+    print('    if (v.%s.empty() || %s)'%(field.name, inline))
+    print('      s << "[";')
     print('    for (size_t i = 0; i < v.%s.size(); ++i)'%(field.name))
     print('    {')
-    print('      s << indent << "  %s[" << i << "]: ";'%(field.name))
-    indent_increment = '  '
-    if (not field.is_builtin):
-      print('      s << std::endl;')
-      print('      s << indent;')
-      indent_increment = '    ';
-    print('      Printer<%s>::stream(s, indent + "%s", v.%s[i]);'%(cpp_type, indent_increment, field.name))
+    print('      if (%s && i > 0)'%(inline))
+    print('        s << ", ";')
+    print('      else if (!%s)'%(inline))
+    print('        s << std::endl << indent << "  -";')
+    print('      Printer<%s>::stream(s, %s ? std::string() : indent + "    ", v.%s[i]);'%(cpp_type, inline, field.name))
     print('    }')
+    print('    if (v.%s.empty() || %s)'%(field.name, inline))
+    print('      s << "]";')
   else:
-    print('    s << indent << "%s: ";'%(field.name))
-    indent_increment = '  '
-    if (not field.is_builtin or field.is_array):
-      print('    s << std::endl;')
-    print('    Printer<%s>::stream(s, indent + "%s", v.%s);'%(cpp_type, indent_increment, field.name))
+    print('    Printer<%s>::stream(s, indent + "  ", v.%s);'%(cpp_type, field.name))
 }@
   }
 @[else]@


### PR DESCRIPTION
I put this patch here for visibility. @rhaschke pushed it to the ROS-O fork last year.

Robert: Maybe you can comment with an example for completeness?
I believe this is related to message parsing in the context of MTC properties, right?